### PR TITLE
added logout button to appBar

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -39,3 +39,9 @@ i {
   font-size: 24px !important;
   padding-right: 4px;
 }
+
+.icon {
+  font-size: 24px !important;
+  padding-right: 4px;
+  text-decoration: none;
+}

--- a/app/views/layouts/main.html.erb
+++ b/app/views/layouts/main.html.erb
@@ -35,6 +35,7 @@
       </div>
       <div class="PageHeader-appBar">
         <i class="fa fa-search PageHeader-search"></i>
+        <a rel="nofollow" data-method="delete" href="/users/sign_out" class="icon fa fa fa-sign-out PageHeader-search"></a>
       </div>
     </div>
     <div class="MainContainer-content">


### PR DESCRIPTION
added logout button to appBar in the top right by search icon.  I use a regular a href instead of link_to, which may be good or bad.

I also added a class for the link/icon to make it the same size as the icons and not have an underline.
