### PR TITLE
defect: set filename on upload which also causes it to be correct on …

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -65,8 +65,8 @@ class AttachmentFileUploader < CarrierWave::Uploader::Base
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
+  def filename
+    model.file_name
+  end
 
 end


### PR DESCRIPTION
…download

Filenames on Amazon were getting set to a generic file.ext.  This fixes that by giving it the right name on upload which is the defaut for download
